### PR TITLE
updating containers needed for LIGO DL inference-as-a-service

### DIFF
--- a/docker_images.txt
+++ b/docker_images.txt
@@ -361,7 +361,8 @@ containers.ligo.org/james-clark/tgr_images/lalsuite-master:latest
 containers.ligo.org/alec.gunny/deepclean-prod:export-20.07
 containers.ligo.org/alec.gunny/deepclean-prod:client-20.07
 containers.ligo.org/alec.gunny/deepclean-prod:server-20.07
-fastml/gw-iaas-export
+fastml/gwiaas.export:latest
+fastml/gwiaas.tritonserver:latest
 
 # LIGO/VIRGO/KAGRA containers
 containers.ligo.org/lscsoft/lalsuite/nightly:el7


### PR DESCRIPTION
Changing syntax for fastml IaaS containers and adding a container image for the server which is just the upstream `22.02-py3` [NVIDIA container repo](ngc.nvidia.com) image but retagged to `latest` to make updating production version on LIGO grid easier